### PR TITLE
支出科目設定機能実装

### DIFF
--- a/app/assets/javascripts/costs.coffee
+++ b/app/assets/javascripts/costs.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/costs.scss
+++ b/app/assets/stylesheets/costs.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the costs controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/costs_controller.rb
+++ b/app/controllers/costs_controller.rb
@@ -1,0 +1,50 @@
+class CostsController < ApplicationController
+
+  def index
+    @costs = Cost.order(created_at: :asc)
+  end
+
+  def show
+    @cost = Cost.find(params[:id])
+  end
+
+  def new
+    @cost = Cost.new()
+  end
+
+  def edit
+    @cost = Cost.find(params[:id])
+  end
+
+  def create
+    @cost = Cost.new(cost_params)
+    if @cost.save
+      redirect_to @cost
+    else
+      render "new"
+    end
+  end
+
+  def update
+    @cost = Cost.find(params[:id])
+    @cost.assign_attributes(cost_params)
+    if @cost.save
+      redirect_to @cost
+    else
+      render "new"
+    end
+  end
+
+  def destroy
+    @cost = Cost.find(params[:id])
+    @cost.destroy
+    redirect_to :costs
+  end
+
+  private
+
+  def cost_params
+    params.require(:cost).permit(:name, :description)
+  end
+
+end

--- a/app/helpers/costs_helper.rb
+++ b/app/helpers/costs_helper.rb
@@ -1,0 +1,2 @@
+module CostsHelper
+end

--- a/app/models/cost.rb
+++ b/app/models/cost.rb
@@ -1,0 +1,2 @@
+class Cost < ApplicationRecord
+end

--- a/app/views/costs/_form.html.haml
+++ b/app/views/costs/_form.html.haml
@@ -1,0 +1,8 @@
+= link_to "支出科目一覧に戻る", :costs
+%table
+  %tr
+    %th= form.label :name, "名称"
+    %td= form.text_field :name
+  %tr
+    %th= form.label :description, "説明"
+    %td= form.text_field :description

--- a/app/views/costs/edit.html.haml
+++ b/app/views/costs/edit.html.haml
@@ -1,0 +1,4 @@
+%h2 収入科目編集
+= form_for @cost do |form|
+  =render "form", form: form
+  %div= form.submit

--- a/app/views/costs/edit.html.haml
+++ b/app/views/costs/edit.html.haml
@@ -1,4 +1,4 @@
-%h2 収入科目編集
+%h2 支出科目編集
 = form_for @cost do |form|
   =render "form", form: form
   %div= form.submit

--- a/app/views/costs/index.html.haml
+++ b/app/views/costs/index.html.haml
@@ -2,6 +2,7 @@
 %h2= @page_title
 
 = link_to "支出科目の新規登録", :new_cost
+= link_to "金額入力画面に戻る", :inputs
 
 - if @costs.present?
   %table

--- a/app/views/costs/index.html.haml
+++ b/app/views/costs/index.html.haml
@@ -1,0 +1,21 @@
+- @page_title = "支出科目一覧"
+%h2= @page_title
+
+= link_to "支出科目の新規登録", :new_cost
+
+- if @costs.present?
+  %table
+    %thead
+      %tr
+        %th 科目名
+        %th 備考
+        %th 操作
+    %tbody
+      - @costs.each do |cost|
+        %tr
+          %td= cost.name
+          %td= cost.description
+          %td= link_to "編集", [:edit, cost]
+          %td= link_to "削除", cost, method: :delete
+- else
+  %p 登録されている支出科目がありません。

--- a/app/views/costs/new.html.haml
+++ b/app/views/costs/new.html.haml
@@ -1,4 +1,4 @@
-%h2 収入科目登録
+%h2 支出科目登録
 = form_for @cost do |form|
   = render "form", form: form
   %div= form.submit

--- a/app/views/costs/new.html.haml
+++ b/app/views/costs/new.html.haml
@@ -1,0 +1,4 @@
+%h2 収入科目登録
+= form_for @cost do |form|
+  = render "form", form: form
+  %div= form.submit

--- a/app/views/costs/show.html.haml
+++ b/app/views/costs/show.html.haml
@@ -1,0 +1,13 @@
+%h2 支出科目の詳細
+
+=link_to "編集", [:edit, @cost]
+=link_to "支出科目一覧へ戻る", :costs
+
+%table
+  %tr
+  %th 名称
+  %td= @cost.name
+
+  %tr
+    %th 説明
+    %td= @cost.description

--- a/app/views/inputs/index.html.haml
+++ b/app/views/inputs/index.html.haml
@@ -32,7 +32,7 @@
                           .col-xs-3
                             %span.default-category-name カテゴリ
                             %span.small-category-name 分類
-                            = link_to root_path(current_user) do
+                            = link_to :costs do
                               = icon('fas', 'edit', class: 'icon')
                           .col-xs-3 金額
                           .col-xs-3 メモ

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   root "calenders#index"
   resources :users, only: [:edit, :update]
   resources :inputs
+  resources :costs
 end

--- a/db/migrate/20200107115804_create_costs.rb
+++ b/db/migrate/20200107115804_create_costs.rb
@@ -1,0 +1,9 @@
+class CreateCosts < ActiveRecord::Migration[5.0]
+  def change
+    create_table :costs do |t|
+      t.string :name, null: false
+      t.string :description
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191229153133) do
+ActiveRecord::Schema.define(version: 20200107115804) do
+
+  create_table "costs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "name",        null: false
+    t.string   "description"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",                                null: false

--- a/test/controllers/costs_controller_test.rb
+++ b/test/controllers/costs_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CostsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/costs.yml
+++ b/test/fixtures/costs.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/cost_test.rb
+++ b/test/models/cost_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CostTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
支出科目設定機能を実装した。
マークアップ については別のブランチで実装する。
支出科目の登録・編集・削除ができるように実装。
スクリーンショットの「収入」は「支出」に修正済み

<img width="289" alt="スクリーンショット 2020-01-08 1 40 31" src="https://user-images.githubusercontent.com/57065520/71912547-0de45500-31b9-11ea-8830-e120b37de7ec.png">
<img width="317" alt="スクリーンショット 2020-01-08 1 42 30" src="https://user-images.githubusercontent.com/57065520/71912562-13da3600-31b9-11ea-8bc1-7764055af2ab.png">
<img width="341" alt="スクリーンショット 2020-01-08 1 42 44" src="https://user-images.githubusercontent.com/57065520/71912569-176dbd00-31b9-11ea-8eb1-b54975b73822.png">
<img width="1438" alt="スクリーンショット 2020-01-08 2 04 39" src="https://user-images.githubusercontent.com/57065520/71913818-a1b72080-31bb-11ea-8c1d-c6d005515c9e.png">
