### PR TITLE
収入科目設定機能実装

### DIFF
--- a/app/assets/javascripts/incomes.coffee
+++ b/app/assets/javascripts/incomes.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/incomes.scss
+++ b/app/assets/stylesheets/incomes.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the incomes controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/incomes_controller.rb
+++ b/app/controllers/incomes_controller.rb
@@ -1,0 +1,50 @@
+class IncomesController < ApplicationController
+
+  def index
+    @incomes = Income.order(created_at: :asc)
+  end
+
+  def show
+    @income = Income.find(params[:id])
+  end
+
+  def new
+    @income = Income.new()
+  end
+
+  def edit
+    @income = Income.find(params[:id])
+  end
+
+  def create
+    @income = Income.new(income_params)
+    if @income.save
+      redirect_to @income
+    else
+      render "new"
+    end
+  end
+
+  def update
+    @income = Income.find(params[:id])
+    @income.assign_attributes(income_params)
+    if @income.save
+      redirect_to @income
+    else
+      render "new"
+    end
+  end
+
+  def destroy
+    @income = Income.find(params[:id])
+    @income.destroy
+    redirect_to :incomes
+  end
+
+  private
+
+  def income_params
+    params.require(:income).permit(:name, :description)
+  end
+
+end

--- a/app/helpers/incomes_helper.rb
+++ b/app/helpers/incomes_helper.rb
@@ -1,0 +1,2 @@
+module IncomesHelper
+end

--- a/app/models/income.rb
+++ b/app/models/income.rb
@@ -1,0 +1,2 @@
+class Income < ApplicationRecord
+end

--- a/app/views/incomes/_form.html.haml
+++ b/app/views/incomes/_form.html.haml
@@ -1,0 +1,8 @@
+= link_to "収入科目一覧に戻る", :incomes
+%table
+  %tr
+    %th= form.label :name, "名称"
+    %td= form.text_field :name
+  %tr
+    %th= form.label :description, "説明"
+    %td= form.text_field :description

--- a/app/views/incomes/edit.html.haml
+++ b/app/views/incomes/edit.html.haml
@@ -1,0 +1,4 @@
+%h2 収入科目編集
+= form_for @income do |form|
+  =render "form", form: form
+  %div= form.submit

--- a/app/views/incomes/index.html.haml
+++ b/app/views/incomes/index.html.haml
@@ -1,0 +1,22 @@
+- @page_title = "収入科目一覧"
+%h2= @page_title
+
+= link_to "収入科目の新規登録", :new_income
+= link_to "金額入力画面に戻る", :inputs
+
+- if @incomes.present?
+  %table
+    %thead
+      %tr
+        %th 科目名
+        %th 備考
+        %th 操作
+    %tbody
+      - @incomes.each do |income|
+        %tr
+          %td= income.name
+          %td= income.description
+          %td= link_to "編集", [:edit, income]
+          %td= link_to "削除", income, method: :delete
+- else
+  %P 登録されている収入科目がありません。

--- a/app/views/incomes/new.html.haml
+++ b/app/views/incomes/new.html.haml
@@ -1,0 +1,4 @@
+%h2 収入科目登録
+= form_for @income do |form|
+  = render "form", form: form
+  %div= form.submit

--- a/app/views/incomes/show.html.haml
+++ b/app/views/incomes/show.html.haml
@@ -1,0 +1,12 @@
+%h2 収入科目の詳細
+
+= link_to "編集", [:edit, @income]
+= link_to "収入科目一覧へ戻る", :incomes
+
+%table
+  %tr
+  %th 名称
+  %td= @income.name
+  %tr
+    %th 説明
+    %td= @income.description 

--- a/app/views/inputs/index.html.haml
+++ b/app/views/inputs/index.html.haml
@@ -34,6 +34,8 @@
                             %span.small-category-name 分類
                             = link_to :costs do
                               = icon('fas', 'edit', class: 'icon')
+                            = link_to :incomes do
+                              = icon('fas', 'plus-square', class: 'icon')
                           .col-xs-3 金額
                           .col-xs-3 メモ
                         .row.receipt-item-row

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   resources :users, only: [:edit, :update]
   resources :inputs
   resources :costs
+  resources :incomes
 end

--- a/db/migrate/20200107173100_create_incomes.rb
+++ b/db/migrate/20200107173100_create_incomes.rb
@@ -1,0 +1,9 @@
+class CreateIncomes < ActiveRecord::Migration[5.0]
+  def change
+    create_table :incomes do |t|
+      t.string :name, null: false
+      t.string :description
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200107115804) do
+ActiveRecord::Schema.define(version: 20200107173100) do
 
   create_table "costs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "name",        null: false
+    t.string   "description"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
+
+  create_table "incomes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",        null: false
     t.string   "description"
     t.datetime "created_at",  null: false

--- a/test/controllers/incomes_controller_test.rb
+++ b/test/controllers/incomes_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class IncomesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/incomes.yml
+++ b/test/fixtures/incomes.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/income_test.rb
+++ b/test/models/income_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class IncomeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#What
収入科目設定機能を実装した。
画面のマークアップについては別のブランチで実装する。
JS実装後、収入金額画面を作成するため、遷移するためのアイコンは仮置き

<img width="314" alt="スクリーンショット 2020-01-08 14 39 38" src="https://user-images.githubusercontent.com/57065520/71953212-d90de780-3224-11ea-9200-3c0c87fb82eb.png">
<img width="336" alt="スクリーンショット 2020-01-08 14 39 48" src="https://user-images.githubusercontent.com/57065520/71953217-dca16e80-3224-11ea-9e4d-bdf782859c5c.png">
<img width="352" alt="スクリーンショット 2020-01-08 14 39 58" src="https://user-images.githubusercontent.com/57065520/71953218-df03c880-3224-11ea-9dcb-5db07cc81059.png">
<img width="1438" alt="スクリーンショット 2020-01-08 14 37 50" src="https://user-images.githubusercontent.com/57065520/71953224-e2974f80-3224-11ea-8b87-11a2ac66d8ae.png">
